### PR TITLE
Integrate TheAppManager module system

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -2,12 +2,11 @@
   <PropertyGroup>
     <ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
-
   <ItemGroup>
     <!-- Library -->
     <PackageVersion Include="Microsoft.Extensions.Http" Version="10.0.5" />
-
     <!-- Test packages -->
+    <PackageVersion Include="TheAppManager" Version="2.0.0" />
     <PackageVersion Include="xunit" Version="2.9.3" />
     <PackageVersion Include="xunit.runner.visualstudio" Version="3.1.5" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="18.3.0" />

--- a/web/VatBe.Web/Modules/BlazorModule.cs
+++ b/web/VatBe.Web/Modules/BlazorModule.cs
@@ -1,0 +1,31 @@
+using TheAppManager.Modules;
+using VatBe.Web.Components;
+
+namespace VatBe.Web.Modules;
+
+public class BlazorModule : IAppModule
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Services.AddRazorComponents()
+            .AddInteractiveServerComponents();
+    }
+
+    public void ConfigureMiddleware(WebApplication app)
+    {
+        if (!app.Environment.IsDevelopment())
+        {
+            app.UseExceptionHandler("/Error");
+            app.UseHsts();
+        }
+
+        app.UseStaticFiles();
+        app.UseAntiforgery();
+    }
+
+    public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapRazorComponents<App>()
+            .AddInteractiveServerRenderMode();
+    }
+}

--- a/web/VatBe.Web/Modules/DataProtectionModule.cs
+++ b/web/VatBe.Web/Modules/DataProtectionModule.cs
@@ -1,0 +1,21 @@
+using Microsoft.AspNetCore.DataProtection;
+using TheAppManager.Modules;
+
+namespace VatBe.Web.Modules;
+
+public class DataProtectionModule : IAppModule
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        var dataProtectionPath = builder.Configuration.GetValue<string>("DataProtection:KeyPath");
+        if (!string.IsNullOrWhiteSpace(dataProtectionPath))
+        {
+            var keyDir = new DirectoryInfo(dataProtectionPath);
+            if (!keyDir.Exists) keyDir.Create();
+
+            builder.Services.AddDataProtection()
+                .PersistKeysToFileSystem(keyDir)
+                .SetApplicationName("VatBe");
+        }
+    }
+}

--- a/web/VatBe.Web/Modules/HealthChecksModule.cs
+++ b/web/VatBe.Web/Modules/HealthChecksModule.cs
@@ -1,0 +1,16 @@
+using TheAppManager.Modules;
+
+namespace VatBe.Web.Modules;
+
+public class HealthChecksModule : IAppModule
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Services.AddHealthChecks();
+    }
+
+    public void ConfigureEndpoints(IEndpointRouteBuilder endpoints)
+    {
+        endpoints.MapHealthChecks("/health");
+    }
+}

--- a/web/VatBe.Web/Modules/VatBeModule.cs
+++ b/web/VatBe.Web/Modules/VatBeModule.cs
@@ -1,0 +1,11 @@
+using TheAppManager.Modules;
+
+namespace VatBe.Web.Modules;
+
+public class VatBeModule : IAppModule
+{
+    public void ConfigureServices(WebApplicationBuilder builder)
+    {
+        builder.Services.AddVatBe();
+    }
+}

--- a/web/VatBe.Web/Program.cs
+++ b/web/VatBe.Web/Program.cs
@@ -1,45 +1,11 @@
-using Microsoft.AspNetCore.DataProtection;
-using VatBe;
-using VatBe.Web.Components;
+using TheAppManager.Startup;
+using VatBe.Web.Modules;
 
-var builder = WebApplication.CreateBuilder(args);
-
-// ─────────────────────────────────────────────────────────────────────────────
-// Data Protection — shared keys for multi-pod Blazor Server deployment
-// ─────────────────────────────────────────────────────────────────────────────
-var dataProtectionPath = builder.Configuration.GetValue<string>("DataProtection:KeyPath");
-if (!string.IsNullOrWhiteSpace(dataProtectionPath))
+AppManager.Start(args, modules =>
 {
-    var keyDir = new DirectoryInfo(dataProtectionPath);
-    if (!keyDir.Exists) keyDir.Create();
-    
-    builder.Services.AddDataProtection()
-        .PersistKeysToFileSystem(keyDir)
-        .SetApplicationName("VatBe");
-}
-
-builder.Services.AddRazorComponents()
-    .AddInteractiveServerComponents();
-
-// VatBe: IViesClient + typed HttpClient with Polly resilience
-builder.Services.AddVatBe();
-
-builder.Services.AddHealthChecks();
-
-var app = builder.Build();
-
-if (!app.Environment.IsDevelopment())
-{
-    app.UseExceptionHandler("/Error");
-    app.UseHsts();
-}
-
-app.UseStaticFiles();
-app.UseAntiforgery();
-
-app.MapHealthChecks("/health");
-
-app.MapRazorComponents<App>()
-    .AddInteractiveServerRenderMode();
-
-app.Run();
+    modules
+        .Add<DataProtectionModule>()
+        .Add<BlazorModule>()
+        .Add<VatBeModule>()
+        .Add<HealthChecksModule>();
+});

--- a/web/VatBe.Web/VatBe.Web.csproj
+++ b/web/VatBe.Web/VatBe.Web.csproj
@@ -10,4 +10,8 @@
     <ProjectReference Include="..\..\src\VatBe\VatBe.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <PackageReference Include="TheAppManager" />
+  </ItemGroup>
+
 </Project>


### PR DESCRIPTION
## Summary
- Integrated TheAppManager 2.0.0 NuGet package to organize application startup into composable modules
- Refactored Program.cs to use `AppManager.Start()` with modular configuration
- Split startup into four focused modules: DataProtectionModule, BlazorModule, VatBeModule, HealthChecksModule
- All original service registrations, middleware, and endpoint mappings are preserved exactly

## Test plan
- [x] Solution compiles successfully (`dotnet build web/VatBe.Web/VatBe.Web.csproj`)
- [x] No business logic changes — only startup reorganization
- [ ] Manual smoke test: run the web app and verify Blazor pages load correctly
- [ ] Verify `/health` endpoint responds with 200 OK

> **Note:** The test project has a pre-existing build issue (references `Shouldly` but only `FluentAssertions` is in the package list). This is unrelated to this PR.